### PR TITLE
Make `linguist` detect SQL files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sql linguist-detectable=true


### PR DESCRIPTION
It looks like SQL files are non-detectable by default for linguist.  Before PR:
```console
$ github-linguist 
53.86%  32222      Python
31.94%  19109      Hy
11.29%  6755       R
1.46%   872        Shell
1.44%   862        Makefile
```
After PR:
```console
$ github-linguist 
46.75%  32222      Python
27.72%  19109      Hy
13.21%  9104       SQL
9.80%   6755       R
1.27%   872        Shell
1.25%   862        Makefile
```